### PR TITLE
Fix: autoreload, restrict eventhandler from restart on open

### DIFF
--- a/sdk/python/packages/flet/src/flet/cli/commands/run.py
+++ b/sdk/python/packages/flet/src/flet/cli/commands/run.py
@@ -288,7 +288,10 @@ class Handler(FileSystemEventHandler):
             ):
                 return
 
-        if self.watch_directory or event.src_path == self.script_path:
+        if (
+            self.watch_directory or event.src_path == self.script_path
+            ) and event.event_type in ["modified", "deleted", "created", "moved"]:
+
             current_time = time.time()
             if (current_time - self.last_time) > 0.5 and self.is_running:
                 self.last_time = current_time


### PR DESCRIPTION
This address #3097 , Limit the restart of the running flet app to modify, created, deleted or moved file events